### PR TITLE
Update macdylibbundler source to support Big Sur

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
 DESTDIR=
 PREFIX=/usr/local
-CXXFLAGS = -O2
+CXXFLAGS=-O2 -std=c++11
+
+CPP_FILES=$(wildcard src/*.cpp)
+OBJ_FILES=$(notdir $(CPP_FILES:.cpp=.o))
 
 all: dylibbundler
 
-dylibbundler:
-	$(CXX) $(CXXFLAGS) -c -I./src ./src/Settings.cpp -o ./Settings.o
-	$(CXX) $(CXXFLAGS) -c -I./src ./src/DylibBundler.cpp -o ./DylibBundler.o
-	$(CXX) $(CXXFLAGS) -c -I./src ./src/Dependency.cpp -o ./Dependency.o
-	$(CXX) $(CXXFLAGS) -c -I./src ./src/main.cpp -o ./main.o
-	$(CXX) $(CXXFLAGS) -c -I./src ./src/Utils.cpp -o ./Utils.o
-	$(CXX) $(CXXFLAGS) -o ./dylibbundler ./Settings.o ./DylibBundler.o ./Dependency.o ./main.o ./Utils.o
+dylibbundler: $(OBJ_FILES)
+	$(CXX) $(CXXFLAGS) -o $@ $(OBJ_FILES)
+
+%.o: src/%.cpp
+	$(CXX) -c $(CXXFLAGS) -I./src $< -o $@
 
 clean:
 	rm -f *.o

--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ fixes dependencies where bundled libraries depend on each other. If this option 
 `-i`, `--ignore` (path)
 > Dylibs in (path) will be ignored. By default, dylibbundler will ignore libraries installed in `/usr/lib` since they are assumed to be present by default on all OS X installations.*(It is usually recommend not to install additional stuff in `/usr/`, always use ` /usr/local/` or another prefix to avoid confusion between system libs and libs you added yourself)*
 
-
 `-d`, `--dest-dir` (directory)
 > Sets the name of the directory in wich distribution-ready dylibs will be placed, relative to the current working directory. (Default is `./libs`) For an app bundle, it is often conveniant to set it to something like `./MyApp.app/Contents/libs`.
-
 
 `-p`, `--install-path` (libraries install path)
 > Sets the "inner" installation path of libraries, usually inside the bundle and relative to executable. (Default is `@executable_path/../libs/`, which points to a directory named `libs` inside the `Contents` directory of the bundle.)
 
+`-s`, `--search-path` (search path)
+> Check for libraries in the specified path
 
 *The difference between `-d` and `-p` is that `-d` is the location dylibbundler will put files at, while `-p` is the location where the libraries will be expected to be found when you launch the app. Both are often related.*
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Mac OS X introduced an innovative and very useful way to package applications : 
 While their design has all that is needed to ease distribution of resources and frameworks, it
 seems like dynamic libraries (.dylib) are very complicated to distribute. Sure, applications developed
 specifically for OS X won't make use of them, however applications ported from Linux or other Unices may have
-dependencies that will only compile as dylibs. By default, there exists no mechanism to bundle them but some command-line utilities provided by Apple - however it turns out that for a single program it is often necessary to issue dozens of commands! This often leads each porter to develop their own "home solution" wich are often hacky, poorly portable and/or nonoptimal.
+dependencies that will only compile as dylibs. By default, there exists no mechanism to bundle them but some command-line utilities provided by Apple - however it turns out that for a single program it is often necessary to issue dozens of commands! This often leads each porter to develop their own "home solution" wich are often hacky, poorly portable and/or non-optimal.
 
 **dylibbundler** is a small command-line programs that aims to make bundling .dylibs as easy as possible.
-It automatically determines which dylibs are needed by your program, copies these libraries inside the app bundle, and fixes both them and the executable to be ready for distribution... all this with a single command on the teminal! It will also work if your program uses plug-ins that have dependencies too.
+It automatically determines which dylibs are needed by your program, copies these libraries inside the app bundle, and fixes both them and the executable to be ready for distribution... all this with a single command on the terminal! It will also work if your program uses plug-ins that have dependencies too.
 
 It usually involves 2 actions :
 * Creating a directory (by default called *libs*) that can be placed inside the *Contents* folder of the app bundle.
@@ -57,7 +57,7 @@ fixes dependencies where bundled libraries depend on each other. If this option 
 > Dylibs in (path) will be ignored. By default, dylibbundler will ignore libraries installed in `/usr/lib` since they are assumed to be present by default on all OS X installations.*(It is usually recommend not to install additional stuff in `/usr/`, always use ` /usr/local/` or another prefix to avoid confusion between system libs and libs you added yourself)*
 
 `-d`, `--dest-dir` (directory)
-> Sets the name of the directory in wich distribution-ready dylibs will be placed, relative to the current working directory. (Default is `./libs`) For an app bundle, it is often conveniant to set it to something like `./MyApp.app/Contents/libs`.
+> Sets the name of the directory in which distribution-ready dylibs will be placed, relative to the current working directory. (Default is `./libs`) For an app bundle, it is often convenient to set it to something like `./MyApp.app/Contents/libs`.
 
 `-p`, `--install-path` (libraries install path)
 > Sets the "inner" installation path of libraries, usually inside the bundle and relative to executable. (Default is `@executable_path/../libs/`, which points to a directory named `libs` inside the `Contents` directory of the bundle.)
@@ -80,7 +80,7 @@ A command may look like
 `% dylibbundler -od -b -x ./HelloWorld.app/Contents/MacOS/helloworld -d ./HelloWorld.app/Contents/libs/`
 
 
-If you want to create a universal binary by merging toghether two builds from PPC and Intel machines, you can ease it up by putting the ppc and intel libs in different directories, then to create the universal binary you only have to lipo the executable.
+If you want to create a universal binary by merging together two builds from PPC and Intel machines, you can ease it up by putting the ppc and intel libs in different directories, then to create the universal binary you only have to lipo the executable.
 <code>
 <pre>
 % dylibbundler -od -b -x ./HelloWorld.app/Contents/MacOS/helloworld

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -215,7 +215,7 @@ void Dependency::fixFileThatDependsOnMe(std::string file_to_fix)
     
     if( systemp( command ) != 0 )
     {
-        std::cerr << "\n\nError : An error occured while trying to fix depencies of " << file_to_fix << std::endl;
+        std::cerr << "\n\nError : An error occured while trying to fix dependencies of " << file_to_fix << std::endl;
         exit(1);
     }
     
@@ -228,7 +228,7 @@ void Dependency::fixFileThatDependsOnMe(std::string file_to_fix)
         
         if( systemp( command ) != 0 )
         {
-            std::cerr << "\n\nError : An error occured while trying to fix depencies of " << file_to_fix << std::endl;
+            std::cerr << "\n\nError : An error occured while trying to fix dependencies of " << file_to_fix << std::endl;
             exit(1);
         }
     }
@@ -243,7 +243,7 @@ void Dependency::fixFileThatDependsOnMe(std::string file_to_fix)
         
         if( systemp( command ) != 0 )
         {
-            std::cerr << "\n\nError : An error occured while trying to fix depencies of " << file_to_fix << std::endl;
+            std::cerr << "\n\nError : An error occured while trying to fix dependencies of " << file_to_fix << std::endl;
             exit(1);
         }
         
@@ -256,7 +256,7 @@ void Dependency::fixFileThatDependsOnMe(std::string file_to_fix)
             
             if( systemp( command ) != 0 )
             {
-                std::cerr << "\n\nError : An error occured while trying to fix depencies of " << file_to_fix << std::endl;
+                std::cerr << "\n\nError : An error occured while trying to fix dependencies of " << file_to_fix << std::endl;
                 exit(1);
             }
         }//next

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -210,55 +210,24 @@ void Dependency::copyYourself()
 void Dependency::fixFileThatDependsOnMe(std::string file_to_fix)
 {
     // for main lib file
-    std::string command = std::string("install_name_tool -change ") +
-    getOriginalPath() + " " + getInnerPath() + " " + file_to_fix;
-    
-    if( systemp( command ) != 0 )
-    {
-        std::cerr << "\n\nError : An error occured while trying to fix dependencies of " << file_to_fix << std::endl;
-        exit(1);
-    }
-    
+    changeInstallName(file_to_fix, getOriginalPath(), getInnerPath());
     // for symlinks
     const int symamount = symlinks.size();
     for(int n=0; n<symamount; n++)
     {
-        command = std::string("install_name_tool -change ") +
-        symlinks[n] + " " + getInnerPath() + " " + file_to_fix;
-        
-        if( systemp( command ) != 0 )
-        {
-            std::cerr << "\n\nError : An error occured while trying to fix dependencies of " << file_to_fix << std::endl;
-            exit(1);
-        }
+        changeInstallName(file_to_fix, symlinks[n], getInnerPath());
     }
-    
     
     // FIXME - hackish
     if(missing_prefixes)
     {
         // for main lib file
-        command = std::string("install_name_tool -change ") +
-        filename + " " + getInnerPath() + " " + file_to_fix;
-        
-        if( systemp( command ) != 0 )
-        {
-            std::cerr << "\n\nError : An error occured while trying to fix dependencies of " << file_to_fix << std::endl;
-            exit(1);
-        }
-        
+        changeInstallName(file_to_fix, filename, getInnerPath());
         // for symlinks
         const int symamount = symlinks.size();
         for(int n=0; n<symamount; n++)
         {
-            command = std::string("install_name_tool -change ") +
-            symlinks[n] + " " + getInnerPath() + " " + file_to_fix;
-            
-            if( systemp( command ) != 0 )
-            {
-                std::cerr << "\n\nError : An error occured while trying to fix dependencies of " << file_to_fix << std::endl;
-                exit(1);
-            }
-        }//next
-    }// end if(missing_prefixes)
+            changeInstallName(file_to_fix, symlinks[n], getInnerPath());
+        }
+    }
 }

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -45,7 +45,7 @@ std::string stripPrefix(std::string in)
 }
 
 std::string& rtrim(std::string &s) {
-    s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char c){ return !std::isspace(c); }).base(), s.end());
     return s;
 }
 

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -199,7 +199,7 @@ void Dependency::copyYourself()
     copyFile(getOriginalPath(), getInstallPath());
     
     // Fix the lib's inner name
-    std::string command = std::string("install_name_tool -id ") + getInnerPath() + " " + getInstallPath();
+    std::string command = std::string("install_name_tool -id \"") + getInnerPath() + "\" \"" + getInstallPath() + "\"";
     if( systemp( command ) != 0 )
     {
         std::cerr << "\n\nError : An error occured while trying to change identity of library " << getInstallPath() << std::endl;

--- a/src/Dependency.h
+++ b/src/Dependency.h
@@ -57,7 +57,7 @@ public:
     void copyYourself();
     void fixFileThatDependsOnMe(std::string file);
     
-    // comapres the given Dependency with this one. If both refer to the same file,
+    // Compares the given dependency with this one. If both refer to the same file,
     // it returns true and merges both entries into one.
     bool mergeIfSameAs(Dependency& dep2);
 };

--- a/src/Dependency.h
+++ b/src/Dependency.h
@@ -39,7 +39,7 @@ class Dependency
     // installation
     std::string new_name;
 public:
-    Dependency(std::string path);
+    Dependency(std::string path, const std::string& dependent_file);
 
     void print();
 
@@ -48,14 +48,14 @@ public:
     std::string getInstallPath();
     std::string getInnerPath();
         
-    void addSymlink(std::string s);
+    void addSymlink(const std::string& s);
     int getSymlinkAmount() const{ return symlinks.size(); }
 
     std::string getSymlink(const int i) const{ return symlinks[i]; }
     std::string getPrefix() const{ return prefix; }
 
     void copyYourself();
-    void fixFileThatDependsOnMe(std::string file);
+    void fixFileThatDependsOnMe(const std::string& file);
     
     // Compares the given dependency with this one. If both refer to the same file,
     // it returns true and merges both entries into one.

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -53,7 +53,7 @@ void changeLibPathsOnFile(std::string file_to_fix)
 
 bool isRpath(const std::string& path)
 {
-    return path.find("@rpath") == 0;
+    return path.find("@rpath") == 0 || path.find("@loader_path") == 0;
 }
 
 void collectRpaths(const std::string& filename)
@@ -114,7 +114,7 @@ std::string searchFilenameInRpaths(const std::string& rpath_file)
 {
     char buffer[PATH_MAX];
     std::string fullpath;
-    std::string suffix = rpath_file.substr(7, rpath_file.size()-6);
+    std::string suffix = rpath_file.substr(rpath_file.rfind("/")+1);
 
     for (std::set<std::string>::iterator it = rpaths.begin(); it != rpaths.end(); ++it)
     {

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -312,16 +312,16 @@ void collectDependencies(const std::string& filename)
 void collectSubDependencies()
 {
     // print status to user
-    int dep_amount = deps.size();
+    size_t dep_amount = deps.size();
     
     // recursively collect each dependencie's dependencies
     while(true)
     {
         dep_amount = deps.size();
-        for (const auto& dep : deps)
+        for (size_t n=0; n<dep_amount; n++)
         {
             std::cout << "."; fflush(stdout);
-            std::string original_path = dep.getOriginalPath();
+            std::string original_path = deps[n].getOriginalPath();
             if (isRpath(original_path)) original_path = searchFilenameInRpaths(original_path);
 
             collectDependencies(original_path);

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include <cstdlib>
 #include <set>
 #include <map>
+#include <sys/param.h>
 #ifdef __linux
 #include <linux/limits.h>
 #endif

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -252,6 +252,7 @@ void collectDependencies(std::string filename)
 
         // trim useless info, keep only library name
         std::string dep_path = lines[n].substr(1, lines[n].rfind(" (") - 1);
+        if (Settings::isSystemLibrary(dep_path)) continue;
         if (isRpath(dep_path))
         {
             collectRpathsForFilename(filename);
@@ -261,6 +262,7 @@ void collectDependencies(std::string filename)
     }
     deps_collected[filename] = true;
 }
+
 void collectSubDependencies()
 {
     // print status to user
@@ -290,6 +292,7 @@ void collectSubDependencies()
                 
                 // trim useless info, keep only library name
                 std::string dep_path = lines[n].substr(1, lines[n].rfind(" (") - 1);
+                if (Settings::isSystemLibrary(dep_path)) continue;
                 if (isRpath(dep_path))
                 {
                     collectRpathsForFilename(searchFilenameInRpaths(dep_path));

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -60,7 +60,7 @@ void collectRpaths(const std::string& filename)
 {
     if (!fileExists(filename))
     {
-        std::cerr << "\n/!\\ WARNING : can't collect rpaths for inexistent file '" << filename << "'\n";
+        std::cerr << "\n/!\\ WARNING : can't collect rpaths for nonexistent file '" << filename << "'\n";
         return;
     }
 
@@ -153,7 +153,7 @@ void fixRpathsOnFile(const std::string& original_file, const std::string& file_t
                 rpaths_to_fix[i] + " " + Settings::inside_lib_path() + " " + file_to_fix;
         if ( systemp(command) != 0)
         {
-            std::cerr << "\n\nError : An error occured while trying to fix depencies of " << file_to_fix << std::endl;
+            std::cerr << "\n\nError : An error occured while trying to fix dependencies of " << file_to_fix << std::endl;
             exit(1);
         }
     }
@@ -244,7 +244,7 @@ void collectSubDependencies()
             for(int n=0; n<line_amount; n++)
             {
                 if(lines[n][0] != '\t') continue; // only lines beginning with a tab interest us
-                if( lines[n].find(".framework") != std::string::npos ) continue; //Ignore frameworks, we can not handle them
+                if( lines[n].find(".framework") != std::string::npos ) continue; //Ignore frameworks, we cannot handle them
                 
                 // trim useless info, keep only library name
                 std::string dep_path = lines[n].substr(1, lines[n].rfind(" (") - 1);
@@ -275,7 +275,7 @@ void createDestDir()
         std::string command = std::string("rm -r ") + dest_folder;
         if( systemp( command ) != 0)
         {
-            std::cerr << "\n\nError : An error occured while attempting to override dest folder." << std::endl;
+            std::cerr << "\n\nError : An error occured while attempting to overwrite dest folder." << std::endl;
             exit(1);
         }
         dest_exists = false;

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -156,8 +156,8 @@ void fixRpathsOnFile(const std::string& original_file, const std::string& file_t
 
     for (size_t i=0; i < rpaths_to_fix.size(); ++i)
     {
-        std::string command = std::string("install_name_tool -rpath ") +
-                rpaths_to_fix[i] + " " + Settings::inside_lib_path() + " " + file_to_fix;
+        std::string command = std::string("install_name_tool -rpath \"") +
+                rpaths_to_fix[i] + "\" \"" + Settings::inside_lib_path() + "\" \"" + file_to_fix + "\"";
         if ( systemp(command) != 0)
         {
             std::cerr << "\n\nError : An error occured while trying to fix dependencies of " << file_to_fix << std::endl;
@@ -199,7 +199,7 @@ void addDependency(std::string path, std::string filename)
 void collectDependencies(std::string filename, std::vector<std::string>& lines)
 {
     // execute "otool -l" on the given file and collect the command's output
-    std::string cmd = "otool -l " + filename;
+    std::string cmd = "otool -l \"" + filename + "\"";
     std::string output = system_get_output(cmd);
 
     if(output.find("can't open file")!=std::string::npos or output.find("No such file")!=std::string::npos or output.size()<1)
@@ -314,7 +314,7 @@ void createDestDir()
     if(dest_exists and Settings::canOverwriteDir())
     {
         std::cout << "* Erasing old output directory " << dest_folder.c_str() << std::endl;
-        std::string command = std::string("rm -r ") + dest_folder;
+        std::string command = std::string("rm -r \"") + dest_folder + "\"";
         if( systemp( command ) != 0)
         {
             std::cerr << "\n\nError : An error occured while attempting to overwrite dest folder." << std::endl;
@@ -329,7 +329,7 @@ void createDestDir()
         if(Settings::canCreateDir())
         {
             std::cout << "* Creating output directory " << dest_folder.c_str() << std::endl;
-            std::string command = std::string("mkdir -p ") + dest_folder;
+            std::string command = std::string("mkdir -p \"") + dest_folder + "\"";
             if( systemp( command ) != 0)
             {
                 std::cerr << "\n\nError : An error occured while creating dest folder." << std::endl;

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -267,14 +267,12 @@ void collectSubDependencies()
                 
                 // trim useless info, keep only library name
                 std::string dep_path = lines[n].substr(1, lines[n].rfind(" (") - 1);
-                std::string full_path = dep_path;
                 if (isRpath(dep_path))
                 {
-                    full_path = searchFilenameInRpaths(dep_path);
-                    collectRpathsForFilename(full_path);
+                    collectRpathsForFilename(searchFilenameInRpaths(dep_path));
                 }
 
-                addDependency(dep_path, full_path);
+                addDependency(dep_path, original_path);
             }//next
         }//next
         

--- a/src/DylibBundler.h
+++ b/src/DylibBundler.h
@@ -27,10 +27,11 @@ THE SOFTWARE.
 
 #include <string>
 
-void collectDependencies(std::string filename);
+void collectDependencies(const std::string& filename);
 void collectSubDependencies();
 void doneWithDeps_go();
 bool isRpath(const std::string& path);
+std::string searchFilenameInRpaths(const std::string& rpath_file, const std::string& dependent_file);
 std::string searchFilenameInRpaths(const std::string& rpath_dep);
 
 #endif

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -76,6 +76,14 @@ void ignore_prefix(std::string prefix)
     prefixes_to_ignore.push_back(prefix);
 }
 
+bool isSystemLibrary(std::string prefix)
+{
+    if(prefix.find("/usr/lib/") == 0) return true;
+    if(prefix.find("/System/Library/") == 0) return true;
+
+    return false;
+}
+
 bool isPrefixIgnored(std::string prefix)
 {
     const int prefix_amount = prefixes_to_ignore.size();
@@ -91,7 +99,7 @@ bool isPrefixBundled(std::string prefix)
 {
     if(prefix.find(".framework") != std::string::npos) return false;
     if(prefix.find("@executable_path") != std::string::npos) return false;
-    if(prefix.compare("/usr/lib/") == 0) return false;
+    if(isSystemLibrary(prefix)) return false;
     if(isPrefixIgnored(prefix)) return false;
     
     return true;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -48,7 +48,7 @@ void bundleLibs(bool on){ bundleLibs_bool = on; }
 
 std::string dest_folder_str = "./libs/";
 std::string destFolder(){ return dest_folder_str; }
-void destFolder(std::string path)
+void destFolder(const std::string& path)
 {
     dest_folder_str = path;
     // fix path if needed so it ends with '/'
@@ -56,13 +56,13 @@ void destFolder(std::string path)
 }
 
 std::vector<std::string> files;
-void addFileToFix(std::string path){ files.push_back(path); }
+void addFileToFix(const std::string& path){ files.push_back(path); }
 int fileToFixAmount(){ return files.size(); }
 std::string fileToFix(const int n){ return files[n]; }
 
 std::string inside_path_str = "@executable_path/../libs/";
 std::string inside_lib_path(){ return inside_path_str; }
-void inside_lib_path(std::string p)
+void inside_lib_path(const std::string& p)
 {
     inside_path_str = p;
     // fix path if needed so it ends with '/'
@@ -76,7 +76,7 @@ void ignore_prefix(std::string prefix)
     prefixes_to_ignore.push_back(prefix);
 }
 
-bool isSystemLibrary(std::string prefix)
+bool isSystemLibrary(const std::string& prefix)
 {
     if(prefix.find("/usr/lib/") == 0) return true;
     if(prefix.find("/System/Library/") == 0) return true;
@@ -84,7 +84,7 @@ bool isSystemLibrary(std::string prefix)
     return false;
 }
 
-bool isPrefixIgnored(std::string prefix)
+bool isPrefixIgnored(const std::string& prefix)
 {
     const int prefix_amount = prefixes_to_ignore.size();
     for(int n=0; n<prefix_amount; n++)
@@ -95,7 +95,7 @@ bool isPrefixIgnored(std::string prefix)
     return false;
 }
 
-bool isPrefixBundled(std::string prefix)
+bool isPrefixBundled(const std::string& prefix)
 {
     if(prefix.find(".framework") != std::string::npos) return false;
     if(prefix.find("@executable_path") != std::string::npos) return false;
@@ -106,7 +106,7 @@ bool isPrefixBundled(std::string prefix)
 }
 
 std::vector<std::string> searchPaths;
-void addSearchPath(std::string path){ searchPaths.push_back(path); }
+void addSearchPath(const std::string& path){ searchPaths.push_back(path); }
 int searchPathAmount(){ return searchPaths.size(); }
 std::string searchPath(const int n){ return searchPaths[n]; }
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -97,4 +97,9 @@ bool isPrefixBundled(std::string prefix)
     return true;
 }
 
+std::vector<std::string> searchPaths;
+void addSearchPath(std::string path){ searchPaths.push_back(path); }
+int searchPathAmount(){ return searchPaths.size(); }
+std::string searchPath(const int n){ return searchPaths[n]; }
+
 }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -29,7 +29,8 @@ THE SOFTWARE.
 
 namespace Settings
 {
-    
+
+bool isSystemLibrary(std::string prefix);
 bool isPrefixBundled(std::string prefix);
 bool isPrefixIgnored(std::string prefix);
 void ignore_prefix(std::string prefix);

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -30,9 +30,9 @@ THE SOFTWARE.
 namespace Settings
 {
 
-bool isSystemLibrary(std::string prefix);
-bool isPrefixBundled(std::string prefix);
-bool isPrefixIgnored(std::string prefix);
+bool isSystemLibrary(const std::string& prefix);
+bool isPrefixBundled(const std::string& prefix);
+bool isPrefixIgnored(const std::string& prefix);
 void ignore_prefix(std::string prefix);
     
 bool canOverwriteFiles();
@@ -48,16 +48,16 @@ bool bundleLibs();
 void bundleLibs(bool on);
 
 std::string destFolder();
-void destFolder(std::string path);
+void destFolder(const std::string& path);
 
-void addFileToFix(std::string path);
+void addFileToFix(const std::string& path);
 int fileToFixAmount();
 std::string fileToFix(const int n);
 
 std::string inside_lib_path();
-void inside_lib_path(std::string p);
+void inside_lib_path(const std::string& p);
 
-void addSearchPath(std::string path);
+void addSearchPath(const std::string& path);
 int searchPathAmount();
 std::string searchPath(const int n);
 

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -56,5 +56,9 @@ std::string fileToFix(const int n);
 std::string inside_lib_path();
 void inside_lib_path(std::string p);
 
+void addSearchPath(std::string path);
+int searchPathAmount();
+std::string searchPath(const int n);
+
 }
 #endif

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -69,7 +69,7 @@ void tokenize(const string& str, const char* delim, vector<string>* vectorarg)
 
 
 
-bool fileExists( std::string filename )
+bool fileExists(const std::string& filename)
 {
     if (access( filename.c_str(), F_OK ) != -1)
     {
@@ -93,10 +93,10 @@ bool fileExists( std::string filename )
     }
 }
 
-void copyFile(string from, string to)
+void copyFile(const string& from, const string& to)
 {
     bool override = Settings::canOverwriteFiles();
-    if(!override)
+    if( from != to && !override )
     {
         if(fileExists( to ))
         {
@@ -124,7 +124,7 @@ void copyFile(string from, string to)
     }
 }
 
-std::string system_get_output(std::string cmd)
+std::string system_get_output(const std::string& cmd)
 {
     FILE * command_output;
     char output[128];
@@ -161,7 +161,7 @@ std::string system_get_output(std::string cmd)
     return full_output;
 }
 
-int systemp(std::string& cmd)
+int systemp(const std::string& cmd)
 {
     std::cout << "    " << cmd.c_str() << std::endl;
     return system(cmd.c_str());
@@ -185,9 +185,8 @@ std::string getUserInputDirForFile(const std::string& filename)
         auto searchPath = Settings::searchPath(n);
         if( !searchPath.empty() && searchPath[ searchPath.size()-1 ] != '/' ) searchPath += "/";
 
-        if( !fileExists( searchPath+filename ) ) {
-            continue;
-        } else {
+        if( fileExists( searchPath+filename ) )
+        {
             std::cerr << (searchPath+filename) << " was found. /!\\ DYLIBBUNDLER MAY NOT CORRECTLY HANDLE THIS DEPENDENCY: Manually check the executable with 'otool -L'" << std::endl;
             return searchPath;
         }
@@ -213,6 +212,7 @@ std::string getUserInputDirForFile(const std::string& filename)
         else
         {
             std::cerr << (prefix+filename) << " was found. /!\\ DYLIBBUNDLER MAY NOT CORRECTLY HANDLE THIS DEPENDENCY: Manually check the executable with 'otool -L'" << std::endl;
+            Settings::addSearchPath(prefix);
             return prefix;
         }
     }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -108,7 +108,7 @@ void copyFile(string from, string to)
     string override_permission = string(override ? "-f " : "-n ");
         
     // copy file to local directory
-    string command = string("cp ") + override_permission + from + string(" ") + to;
+    string command = string("cp ") + override_permission + string("\"") + from + string("\" \"") + to + string("\"");
     if( from != to && systemp( command ) != 0 )
     {
         cerr << "\n\nError : An error occured while trying to copy file " << from << " to " << to << endl;
@@ -116,7 +116,7 @@ void copyFile(string from, string to)
     }
     
     // give it write permission
-    string command2 = string("chmod +w ") + to;
+    string command2 = string("chmod +w \"") + to + "\"";
     if( systemp( command2 ) != 0 )
     {
         cerr << "\n\nError : An error occured while trying to set write permissions on file " << to << endl;
@@ -169,7 +169,7 @@ int systemp(std::string& cmd)
 
 void changeInstallName(const std::string& binary_file, const std::string& old_name, const std::string& new_name)
 {
-    std::string command = std::string("install_name_tool -change ") + old_name + " " + new_name + " " + binary_file;
+    std::string command = std::string("install_name_tool -change \"") + old_name + "\" \"" + new_name + "\" \"" + binary_file + "\"";
     if( systemp( command ) != 0 )
     {
         std::cerr << "\n\nError: An error occured while trying to fix dependencies of " << binary_file << std::endl;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -167,6 +167,16 @@ int systemp(std::string& cmd)
     return system(cmd.c_str());
 }
 
+void changeInstallName(const std::string& binary_file, const std::string& old_name, const std::string& new_name)
+{
+    std::string command = std::string("install_name_tool -change ") + old_name + " " + new_name + " " + binary_file;
+    if( systemp( command ) != 0 )
+    {
+        std::cerr << "\n\nError: An error occured while trying to fix dependencies of " << binary_file << std::endl;
+        exit(1);
+    }
+}
+
 std::string getUserInputDirForFile(const std::string& filename)
 {
     const int searchPathAmount = Settings::searchPathAmount();

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -100,7 +100,7 @@ void copyFile(string from, string to)
     {
         if(fileExists( to ))
         {
-            cerr << "\n\nError : File " << to.c_str() << " already exists. Remove it or enable overriding." << endl;
+            cerr << "\n\nError : File " << to.c_str() << " already exists. Remove it or enable overwriting." << endl;
             exit(1);
         }
     }
@@ -178,14 +178,14 @@ std::string getUserInputDirForFile(const std::string& filename)
         if( !fileExists( searchPath+filename ) ) {
             continue;
         } else {
-            std::cerr << (searchPath+filename) << " was found. /!\\MANUALLY CHECK THE EXECUTABLE WITH 'otool -L', DYLIBBUNDLDER MAY NOT HANDLE CORRECTLY THIS UNSTANDARD/ILL-FORMED DEPENDENCY" << std::endl;
+            std::cerr << (searchPath+filename) << " was found. /!\\ DYLIBBUNDLER MAY NOT CORRECTLY HANDLE THIS DEPENDENCY: Manually check the executable with 'otool -L'" << std::endl;
             return searchPath;
         }
     }
 
     while (true)
     {
-        std::cout << "Please specify now the directory where this library can be found (or write 'quit' to abort): ";  fflush(stdout);
+        std::cout << "Please specify the directory where this library is located (or enter 'quit' to abort): ";  fflush(stdout);
 
         std::string prefix;
         std::cin >> prefix;
@@ -202,7 +202,7 @@ std::string getUserInputDirForFile(const std::string& filename)
         }
         else
         {
-            std::cerr << (prefix+filename) << " was found. /!\\MANUALLY CHECK THE EXECUTABLE WITH 'otool -L', DYLIBBUNDLDER MAY NOT HANDLE CORRECTLY THIS UNSTANDARD/ILL-FORMED DEPENDENCY" << std::endl;
+            std::cerr << (prefix+filename) << " was found. /!\\ DYLIBBUNDLER MAY NOT CORRECTLY HANDLE THIS DEPENDENCY: Manually check the executable with 'otool -L'" << std::endl;
             return prefix;
         }
     }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -169,6 +169,20 @@ int systemp(std::string& cmd)
 
 std::string getUserInputDirForFile(const std::string& filename)
 {
+    const int searchPathAmount = Settings::searchPathAmount();
+    for(int n=0; n<searchPathAmount; n++)
+    {
+        auto searchPath = Settings::searchPath(n);
+        if( !searchPath.empty() && searchPath[ searchPath.size()-1 ] != '/' ) searchPath += "/";
+
+        if( !fileExists( searchPath+filename ) ) {
+            continue;
+        } else {
+            std::cerr << (searchPath+filename) << " was found. /!\\MANUALLY CHECK THE EXECUTABLE WITH 'otool -L', DYLIBBUNDLDER MAY NOT HANDLE CORRECTLY THIS UNSTANDARD/ILL-FORMED DEPENDENCY" << std::endl;
+            return searchPath;
+        }
+    }
+
     while (true)
     {
         std::cout << "Please specify now the directory where this library can be found (or write 'quit' to abort): ";  fflush(stdout);

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -32,15 +32,15 @@ THE SOFTWARE.
 class Library;
 
 void tokenize(const std::string& str, const char* delimiters, std::vector<std::string>*);
-bool fileExists( std::string filename );
+bool fileExists(const std::string& filename);
 
-void copyFile(std::string from, std::string to);
+void copyFile(const std::string& from, const std::string& to);
 
 // executes a command in the native shell and returns output in string
-std::string system_get_output(std::string cmd);
+std::string system_get_output(const std::string& cmd);
 
 // like 'system', runs a command on the system shell, but also prints the command to stdout.
-int systemp(std::string& cmd);
+int systemp(const std::string& cmd);
 void changeInstallName(const std::string& binary_file, const std::string& old_name, const std::string& new_name);
 std::string getUserInputDirForFile(const std::string& filename);
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -41,6 +41,7 @@ std::string system_get_output(std::string cmd);
 
 // like 'system', runs a command on the system shell, but also prints the command to stdout.
 int systemp(std::string& cmd);
+void changeInstallName(const std::string& binary_file, const std::string& old_name, const std::string& new_name);
 std::string getUserInputDirForFile(const std::string& filename);
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,6 +58,7 @@ void showHelp()
     std::cout << "-b, --bundle-deps" << std::endl;
     std::cout << "-d, --dest-dir <directory to send bundled libraries (relative to cwd)>" << std::endl;
     std::cout << "-p, --install-path <'inner' path of bundled libraries (usually relative to executable, by default '@executable_path/../libs/')>" << std::endl;
+    std::cout << "-s, --search-path <directory to add to list of locations searched>" << std::endl;
     std::cout << "-of, --overwrite-files (allow overwriting files in output directory)" << std::endl;
     std::cout << "-od, --overwrite-dir (totally overwrite output directory if it already exists. implies --create-dir)" << std::endl;
     std::cout << "-cd, --create-dir (creates output directory if necessary)" << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,6 +121,12 @@ int main (int argc, char * const argv[])
             showHelp();
             exit(0);    
         }
+        if(strcmp(argv[i],"-s")==0 or strcmp(argv[i],"--search-path")==0)
+        {
+            i++;
+            Settings::addSearchPath(argv[i]);
+            continue;
+        }
         else if(i>0)
         {
             // if we meet an unknown flag, abort


### PR DESCRIPTION
This PR brings esy-macdylibbundler up to date with macdylibbundler, so that this repo works with macOS Big Sur. See onivim/oni2#2813

I can add a simple bash script to automate the update process, but I wasn't sure if it was necessary since it was just a couple of git commands.